### PR TITLE
Don't error if device has no dashboard data

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -147,7 +147,7 @@ class WeatherStation extends Device {
             if(MAX.hasOwnProperty(dataType)) {
                 props.maximum = MAX[dataType];
             }
-            let value = netatmoDevice.dashboard_data.hasOwnProperty(dataType) ? netatmoDevice.dashboard_data[dataType] : NaN;
+            let value = netatmoDevice?.dashboard_data.hasOwnProperty(dataType) ? netatmoDevice.dashboard_data[dataType] : NaN;
             if(dataType == 'health_idx') {
                 props.type = 'string';
                 props.enum = HEALTH_IDX_MAP;


### PR DESCRIPTION
When netatmo devices are offline (out of battery) they report no dashboard data. I'm not sure what typescript version this is using and if using optional chaining with it is already ok.